### PR TITLE
<fix>[zsblk]: fix vm crash when there are a large number of snapshots…

### DIFF
--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -181,6 +181,8 @@ func (mon *SocketMonitor) listen(r io.Reader, events chan<- Event, stream chan<-
 	defer close(stream)
 
 	scanner := bufio.NewScanner(r)
+	buf := make([]byte, 0, 512*1024)
+	scanner.Buffer(buf, 64*1024*1024)
 	for scanner.Scan() {
 		var e Event
 


### PR DESCRIPTION
<fix>[zsblk]: fix vm crash when there are a large number of snapshots at the beginning of vm startup

fix the line returned by qmp 'query-named-block-nodes' cmd is too long to cause "bufio.Scanner: token too long" error

Resolves: ZSTAC-69202

Change-Id: I636174617579656566756b6865798c757a747591